### PR TITLE
Small fix to ADBCommandClient

### DIFF
--- a/src/main/java/gr/aueb/android/barista/core/executor/ADBCommandClient.java
+++ b/src/main/java/gr/aueb/android/barista/core/executor/ADBCommandClient.java
@@ -74,14 +74,20 @@ public class ADBCommandClient implements CommandClient {
 
             // execute the command and wait for its execution
             Process p = pb.start();
-            p.waitFor();
+            pb.redirectErrorStream(true);
 
             // read the output (if any) and pass it tho the result parser of the Command. It is used
             // when the command output is needed.
             BufferedReader output = new BufferedReader(new InputStreamReader(p.getInputStream()));
+            /*String line;
+            while ((line = output.readLine()) != null)
+                System.out.println("tasklist: " + line);*/
             Stream<String> resultStream = output.lines();
+
             cmd.parseResult(resultStream);
             output.close();
+
+            p.waitFor();
 
             // wait until the Command verifies its execution
             while (!cmd.isCompleted(this)){

--- a/src/test/java/gr/aueb/android/barista/core/model/SvcWifiStatusTest.java
+++ b/src/test/java/gr/aueb/android/barista/core/model/SvcWifiStatusTest.java
@@ -1,5 +1,6 @@
 package gr.aueb.android.barista.core.model;
 
+import gr.aueb.android.barista.emulator.EmulatorManager;
 import org.junit.Test;
 
 import java.io.BufferedReader;
@@ -110,7 +111,5 @@ public class SvcWifiStatusTest {
 
         System.out.println(wifiStatus.getStatus());
     }
-
-
 
 }


### PR DESCRIPTION
Fix to ADBCommandClient.

ADB Commands did not terminate because of java class Process.
ABDCommandClient got stuck in pb.waitFor().